### PR TITLE
Add Exception Handling

### DIFF
--- a/src/xpdf-4.04/aconf.h
+++ b/src/xpdf-4.04/aconf.h
@@ -29,7 +29,7 @@
 /*
  * Enable multithreading support.
  */
-#define MULTITHREADED 0
+#define MULTITHREADED 1
 
 /*
  * Enable C++ exceptions.

--- a/src/xpdf-4.04/aconf.h
+++ b/src/xpdf-4.04/aconf.h
@@ -29,7 +29,7 @@
 /*
  * Enable multithreading support.
  */
-#define MULTITHREADED 1
+#define MULTITHREADED 0
 
 /*
  * Enable C++ exceptions.

--- a/src/xpydf/PdfLoader.cc
+++ b/src/xpydf/PdfLoader.cc
@@ -179,5 +179,9 @@ bool PdfLoader::isOk() {
     return false;
   }
 
+int PdfLoader::getErrorCode() {
+	return (int)doc->getErrorCode();
+}	
+  
   return (bool)doc->isOk();
 }

--- a/src/xpydf/PdfLoader.cc
+++ b/src/xpydf/PdfLoader.cc
@@ -182,5 +182,5 @@ bool PdfLoader::isOk() {
 }
 
 int PdfLoader::getErrorCode() {
-	return (int)doc->getErrorCode();
+  return (int)doc->getErrorCode();
 }

--- a/src/xpydf/PdfLoader.cc
+++ b/src/xpydf/PdfLoader.cc
@@ -177,11 +177,10 @@ std::vector<PageImageInfo> PdfLoader::extractImages() {
 bool PdfLoader::isOk() {
   if (!doc) {
     return false;
-  }
+  }  
+  return (bool)doc->isOk();
+}
 
 int PdfLoader::getErrorCode() {
 	return (int)doc->getErrorCode();
-}	
-  
-  return (bool)doc->isOk();
 }

--- a/src/xpydf/PdfLoader.h
+++ b/src/xpydf/PdfLoader.h
@@ -35,6 +35,7 @@ public:
     std::vector<std::string> extractText();
     std::vector<PageImageInfo> extractImages();
     bool isOk();
+	  int getErrorCode();
 private:
   TextOutputControl textOutControl;
   PDFDoc *doc;

--- a/src/xpydf/PdfLoader.h
+++ b/src/xpydf/PdfLoader.h
@@ -35,7 +35,7 @@ public:
     std::vector<std::string> extractText();
     std::vector<PageImageInfo> extractImages();
     bool isOk();
-	  int getErrorCode();
+    int getErrorCode();
 private:
   TextOutputControl textOutControl;
   PDFDoc *doc;

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -40,49 +40,49 @@ PyObject *construct(PyObject *self, PyObject *args) {
 	char message[1000] = "";
         snprintf(message, 1000, "Error loading file %s", fileName);
         PyErr_SetString(PyExc_Exception, message);
-		switch (errCode) {		
-		  default:
-		  case 1: // couldn't open the PDF file
-			snprintf(message, 1000, "Error opening file %s", fileName);
-			PyErr_SetString(PyExc_FileNotFoundError, message);
-			break;
-		  case 2: // couldn't read the page catalog
-			snprintf(message, 1000, "Error parsing PDF catalog in file %s", fileName);
-			PyErr_SetString(PyExc_ImportError, message);
-			break;
-		  case 3: // PDF file was damaged and couldn't be repaired
-		    snprintf(message, 1000, "Error parsing PDF file %s. File might be damaged", fileName);		    
-			PyErr_SetString(PyExc_ImportError, message);
-			break;
-		  case 4: // file was encrypted and password was incorrect or not supplied
-		    snprintf(message, 1000, "Error decrypting PDF file %s", fileName);
-			PyErr_SetString(PyExc_PermissionError, message);
-			break;
-		  case 5: // nonexistent or invalid highlight file
-			snprintf(message, 1000, "Error highlight PDF file %s", fileName);
-			PyErr_SetString(PyExc_FileNotFoundError, message);
-			break;
-		  case 6: // invalid printer
-		    snprintf(message, 1000, "Error bad printer" );
-			PyErr_SetString(PyExc_Exception, message);
-			break;
-		  case 7: // error during printing
-		    snprintf(message, 1000, "Error printing" );
-			PyErr_SetString(PyExc_Exception, message);
-			break;
-		  case 8: // PDF file doesn't allow that operation
-		    snprintf(message, 1000, "Error permissions PDF file %s", fileName);
-			PyErr_SetString(PyExc_PermissionError, message);
-			break;
-		  case 9: // invalid page number
-		    snprintf(message, 1000, "Error bad PDF page number in file %s", fileName);
-			PyErr_SetString(PyExc_ImportError, message);
-			break;
-		  case 10: // file I/O error
-		    snprintf(message, 1000, "Error while read/write file %s", fileName);
-			PyErr_SetString(PyExc_IOError, message);
-			break;
-		}
+	switch (errCode) {		
+	  default:
+	  case 1: // couldn't open the PDF file
+		snprintf(message, 1000, "Error opening file %s", fileName);
+		PyErr_SetString(PyExc_FileNotFoundError, message);
+		break;
+	  case 2: // couldn't read the page catalog
+		snprintf(message, 1000, "Error parsing PDF catalog in file %s", fileName);
+		PyErr_SetString(PyExc_ImportError, message);
+		break;
+	  case 3: // PDF file was damaged and couldn't be repaired
+	    snprintf(message, 1000, "Error parsing PDF file %s. File might be damaged", fileName);		    
+		PyErr_SetString(PyExc_ImportError, message);
+		break;
+	  case 4: // file was encrypted and password was incorrect or not supplied
+	    snprintf(message, 1000, "Error decrypting PDF file %s", fileName);
+		PyErr_SetString(PyExc_PermissionError, message);
+		break;
+	  case 5: // nonexistent or invalid highlight file
+		snprintf(message, 1000, "Error highlight PDF file %s", fileName);
+		PyErr_SetString(PyExc_FileNotFoundError, message);
+		break;
+	  case 6: // invalid printer
+	    snprintf(message, 1000, "Error bad printer" );
+		PyErr_SetString(PyExc_Exception, message);
+		break;
+	  case 7: // error during printing
+	    snprintf(message, 1000, "Error printing" );
+		PyErr_SetString(PyExc_Exception, message);
+		break;
+	  case 8: // PDF file doesn't allow that operation
+	    snprintf(message, 1000, "Error permissions PDF file %s", fileName);
+		PyErr_SetString(PyExc_PermissionError, message);
+		break;
+	  case 9: // invalid page number
+	    snprintf(message, 1000, "Error bad PDF page number in file %s", fileName);
+		PyErr_SetString(PyExc_ImportError, message);
+		break;
+	  case 10: // file I/O error
+	    snprintf(message, 1000, "Error while read/write file %s", fileName);
+		PyErr_SetString(PyExc_IOError, message);
+		break;
+	}
         delete loader;
 	return NULL;
     }

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -6,6 +6,7 @@
 #include "Python.h"
 #include "PdfLoader.h"
 #include "PyCppConversion.h"
+#include "ErrorCodes.h"
 
 using namespace std;
 
@@ -18,7 +19,6 @@ PyObject *construct(PyObject *self, PyObject *args) {
 
     char *ownerPw = NULL;
     char *userPw = NULL;
-    int errCode = NULL;
 
     PyArg_ParseTuple(args, "Opppppbzz", &pobj0,
         &(config.clipText),
@@ -36,58 +36,58 @@ PyObject *construct(PyObject *self, PyObject *args) {
     PdfLoader *loader = new PdfLoader(config, fileName, ownerPw, userPw);
 
     if (!loader->isOk()) {
+        int errCode = NULL;
         errCode = loader->getErrorCode();
-	char message[1000] = "";
-        snprintf(message, 1000, "Error loading file %s", fileName);
-        PyErr_SetString(PyExc_Exception, message);
-	switch (errCode) {		
-	  default:
-	  case 1: // couldn't open the PDF file
-		snprintf(message, 1000, "Error opening file %s", fileName);
-		PyErr_SetString(PyExc_OSError, message);
-		break;
-	  case 2: // couldn't read the page catalog
-		snprintf(message, 1000, "Error parsing PDF catalog in file %s", fileName);
-		PyErr_SetString(PyExc_ImportError, message);
-		break;
-	  case 3: // PDF file was damaged and couldn't be repaired
-	    snprintf(message, 1000, "Error parsing PDF file %s. File might be damaged", fileName);		    
-		PyErr_SetString(PyExc_ImportError, message);
-		break;
-	  case 4: // file was encrypted and password was incorrect or not supplied
-	    snprintf(message, 1000, "Error decrypting PDF file %s", fileName);
-		PyErr_SetString(PyExc_PermissionError, message);
-		break;
-	  case 5: // nonexistent or invalid highlight file
-		snprintf(message, 1000, "Error highlight PDF file %s", fileName);
-		PyErr_SetString(PyExc_OSError, message);
-		break;
-	  case 6: // invalid printer
-	    snprintf(message, 1000, "Error bad printer" );
-		PyErr_SetString(PyExc_Exception, message);
-		break;
-	  case 7: // error during printing
-	    snprintf(message, 1000, "Error printing" );
-		PyErr_SetString(PyExc_Exception, message);
-		break;
-	  case 8: // PDF file doesn't allow that operation
-	    snprintf(message, 1000, "Error permissions PDF file %s", fileName);
-		PyErr_SetString(PyExc_PermissionError, message);
-		break;
-	  case 9: // invalid page number
-	    snprintf(message, 1000, "Error bad PDF page number in file %s", fileName);
-		PyErr_SetString(PyExc_ImportError, message);
-		break;
-	  case 10: // file I/O error
-	    snprintf(message, 1000, "Error while read/write file %s", fileName);
-		PyErr_SetString(PyExc_OSError, message);
-		break;
-	}
+        char message[1000] = "";
+        switch (errCode) {        
+          default:
+            snprintf(message, 1000, "Error loading file %s", fileName);
+            PyErr_SetString(PyExc_Exception, message);
+          case errOpenFile: // couldn't open the PDF file
+            snprintf(message, 1000, "Error opening file %s", fileName);
+            PyErr_SetString(PyExc_OSError, message);
+            break;
+          case errBadCatalog: // couldn't read the page catalog
+            snprintf(message, 1000, "Error parsing PDF catalog in file %s", fileName);
+            PyErr_SetString(PyExc_ImportError, message);
+            break;
+          case errDamaged: // PDF file was damaged and couldn't be repaired
+            snprintf(message, 1000, "Error parsing PDF file %s. File might be damaged", fileName);            
+            PyErr_SetString(PyExc_ImportError, message);
+            break;
+          case errEncrypted: // file was encrypted and password was incorrect or not supplied
+            snprintf(message, 1000, "Error decrypting PDF file %s", fileName);
+            PyErr_SetString(PyExc_PermissionError, message);
+            break;
+          case errHighlightFile: // nonexistent or invalid highlight file
+            snprintf(message, 1000, "Error highlight PDF file %s", fileName);
+            PyErr_SetString(PyExc_OSError, message);
+            break;
+          case errBadPrinter: // invalid printer
+            snprintf(message, 1000, "Error bad printer" );
+            PyErr_SetString(PyExc_Exception, message);
+            break;
+          case errPrinting: // error during printing
+            snprintf(message, 1000, "Error printing" );
+            PyErr_SetString(PyExc_Exception, message);
+            break;
+          case errPermission: // PDF file doesn't allow that operation
+            snprintf(message, 1000, "Error permissions PDF file %s", fileName);
+            PyErr_SetString(PyExc_PermissionError, message);
+            break;
+          case errBadPageNum: // invalid page number
+            snprintf(message, 1000, "Error bad PDF page number in file %s", fileName);
+            PyErr_SetString(PyExc_ImportError, message);
+            break;
+          case errFileIO: // file I/O error
+            snprintf(message, 1000, "Error while read/write file %s", fileName);
+            PyErr_SetString(PyExc_OSError, message);
+            break;
+        }
         delete loader;
-	return NULL;
+    return NULL;
     }
 
-    
     PyObject *loaderCapsule = PyCapsule_New((void *)loader, "loaderPtr", NULL);
     PyCapsule_SetPointer(loaderCapsule, (void *)loader);
     
@@ -125,7 +125,7 @@ PyObject *deleteObject(PyObject *self, PyObject *args) {
     PyArg_ParseTuple(args, "O", &loaderCapsule);
     
     PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
-	
+    
     if (loader) {
         delete loader;
     }

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -44,7 +44,7 @@ PyObject *construct(PyObject *self, PyObject *args) {
 	  default:
 	  case 1: // couldn't open the PDF file
 		snprintf(message, 1000, "Error opening file %s", fileName);
-		PyErr_SetString(PyExc_FileNotFoundError, message);
+		PyErr_SetString(PyExc_OSError, message);
 		break;
 	  case 2: // couldn't read the page catalog
 		snprintf(message, 1000, "Error parsing PDF catalog in file %s", fileName);
@@ -60,7 +60,7 @@ PyObject *construct(PyObject *self, PyObject *args) {
 		break;
 	  case 5: // nonexistent or invalid highlight file
 		snprintf(message, 1000, "Error highlight PDF file %s", fileName);
-		PyErr_SetString(PyExc_FileNotFoundError, message);
+		PyErr_SetString(PyExc_OSError, message);
 		break;
 	  case 6: // invalid printer
 	    snprintf(message, 1000, "Error bad printer" );
@@ -80,7 +80,7 @@ PyObject *construct(PyObject *self, PyObject *args) {
 		break;
 	  case 10: // file I/O error
 	    snprintf(message, 1000, "Error while read/write file %s", fileName);
-		PyErr_SetString(PyExc_IOError, message);
+		PyErr_SetString(PyExc_OSError, message);
 		break;
 	}
         delete loader;

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -18,6 +18,7 @@ PyObject *construct(PyObject *self, PyObject *args) {
 
     char *ownerPw = NULL;
     char *userPw = NULL;
+    int errCode = NULL;
 
     PyArg_ParseTuple(args, "Opppppbzz", &pobj0,
         &(config.clipText),

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -43,6 +43,7 @@ PyObject *construct(PyObject *self, PyObject *args) {
           default:
             snprintf(message, 1000, "Error loading file %s", fileName);
             PyErr_SetString(PyExc_Exception, message);
+            break;
           case errOpenFile: // couldn't open the PDF file
             snprintf(message, 1000, "Error opening file %s", fileName);
             PyErr_SetString(PyExc_OSError, message);

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -85,7 +85,7 @@ PyObject *construct(PyObject *self, PyObject *args) {
             break;
         }
         delete loader;
-    return NULL;
+        return NULL;
     }
 
     PyObject *loaderCapsule = PyCapsule_New((void *)loader, "loaderPtr", NULL);

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -132,7 +132,6 @@ PyObject *deleteObject(PyObject *self, PyObject *args) {
         delete loader;
 		return NULL;
     }
- 
     
     if (loader) {
         delete loader;
@@ -169,7 +168,6 @@ PyMethodDef cXpdfPythonFunctions[] = {
                                // importing the module.
 };
 
-
 struct PyModuleDef cXpdfPythonModule = {
 /*
  *  Structure which defines the module.
@@ -185,7 +183,6 @@ struct PyModuleDef cXpdfPythonModule = {
                          // it is then you do not need it, keep -1 .
    cXpdfPythonFunctions
 };
-
 
 PyMODINIT_FUNC PyInit_cXpdfPython(void) {
     return PyModule_Create(&cXpdfPythonModule);

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -79,6 +79,60 @@ PyObject *deleteObject(PyObject *self, PyObject *args) {
     PyArg_ParseTuple(args, "O", &loaderCapsule);
     
     PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
+
+    errCode = loader->getErrorCode();
+	
+    if (!loader->isOk()) {
+        char message[1000] = "";
+        snprintf(message, 1000, "Error loading file %s", fileName);
+        PyErr_SetString(PyExc_Exception, message);
+		switch (errCode) {		
+		  default:
+		  case 1: // couldn't open the PDF file
+			snprintf(message, 1000, "Error opening file %s", fileName);
+			PyErr_SetString(PyExc_FileNotFoundError, message);
+			break;
+		  case 2: // couldn't read the page catalog
+			snprintf(message, 1000, "Error parsing PDF catalog in file %s", fileName);
+			PyErr_SetString(PyExc_ImportError, message);
+			break;
+		  case 3: // PDF file was damaged and couldn't be repaired
+		    snprintf(message, 1000, "Error parsing PDF file %s. File might be damaged", fileName);		    
+			PyErr_SetString(PyExc_ImportError, message);
+			break;
+		  case 4: // file was encrypted and password was incorrect or not supplied
+		    snprintf(message, 1000, "Error decrypting PDF file %s", fileName);
+			PyErr_SetString(PyExc_PermissionError, message);
+			break;
+		  case 5: // nonexistent or invalid highlight file
+			snprintf(message, 1000, "Error highlight PDF file %s", fileName);
+			PyErr_SetString(PyExc_FileNotFoundError, message);
+			break;
+		  case 6: // invalid printer
+		    snprintf(message, 1000, "Error bad printer" );
+			PyErr_SetString(PyExc_Exception, message);
+			break;
+		  case 7: // error during printing
+		    snprintf(message, 1000, "Error printing" );
+			PyErr_SetString(PyExc_Exception, message);
+			break;
+		  case 8: // PDF file doesn't allow that operation
+		    snprintf(message, 1000, "Error permissions PDF file %s", fileName);
+			PyErr_SetString(PyExc_PermissionError, message);
+			break;
+		  case 9: // invalid page number
+		    snprintf(message, 1000, "Error bad PDF page number in file %s", fileName);
+			PyErr_SetString(PyExc_ImportError, message);
+			break;
+		  case 10: // file I/O error
+		    snprintf(message, 1000, "Error while read/write file %s", fileName);
+			PyErr_SetString(PyExc_IOError, message);
+			break;
+		}
+        delete loader;
+		return NULL;
+    }
+ 
     
     if (loader) {
         delete loader;

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -35,52 +35,6 @@ PyObject *construct(PyObject *self, PyObject *args) {
     
     PdfLoader *loader = new PdfLoader(config, fileName, ownerPw, userPw);
 
-    if (!loader->isOk()) {
-        char message[1000] = "";
-        snprintf(message, 1000, "Error loading file %s", fileName);
-        PyErr_SetString(PyExc_IOError, message);
-        delete loader;
-        return NULL;
-    }
-    
-    PyObject *loaderCapsule = PyCapsule_New((void *)loader, "loaderPtr", NULL);
-    PyCapsule_SetPointer(loaderCapsule, (void *)loader);
-    
-    return loaderCapsule;
-}
-
-PyObject *extractText(PyObject *self, PyObject *args) {
-    vector<string> res;
-    
-    PyObject *loaderCapsule;
-    PyArg_ParseTuple(args, "O", &loaderCapsule);
-
-    PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
-    vector<string> result = loader->extractText();
-    
-    PyObject *converted = vectorStringToList(result);
-    return Py_BuildValue("O", converted);
-}
-
-PyObject *extractImages(PyObject *self, PyObject *args) {
-    vector<string> res;
-    
-    PyObject *loaderCapsule;
-    PyArg_ParseTuple(args, "O", &loaderCapsule);
-
-    PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
-    vector<PageImageInfo> result = loader->extractImages();
-    
-    PyObject *converted = vectorPagesToList(result);
-    return Py_BuildValue("O", converted);
-}
-
-PyObject *deleteObject(PyObject *self, PyObject *args) {
-    PyObject *loaderCapsule;
-    PyArg_ParseTuple(args, "O", &loaderCapsule);
-    
-    PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
-
     errCode = loader->getErrorCode();
 	
     if (!loader->isOk()) {
@@ -131,9 +85,48 @@ PyObject *deleteObject(PyObject *self, PyObject *args) {
 			break;
 		}
         delete loader;
-		return NULL;
+	return NULL;
     }
+
     
+    PyObject *loaderCapsule = PyCapsule_New((void *)loader, "loaderPtr", NULL);
+    PyCapsule_SetPointer(loaderCapsule, (void *)loader);
+    
+    return loaderCapsule;
+}
+
+PyObject *extractText(PyObject *self, PyObject *args) {
+    vector<string> res;
+    
+    PyObject *loaderCapsule;
+    PyArg_ParseTuple(args, "O", &loaderCapsule);
+
+    PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
+    vector<string> result = loader->extractText();
+    
+    PyObject *converted = vectorStringToList(result);
+    return Py_BuildValue("O", converted);
+}
+
+PyObject *extractImages(PyObject *self, PyObject *args) {
+    vector<string> res;
+    
+    PyObject *loaderCapsule;
+    PyArg_ParseTuple(args, "O", &loaderCapsule);
+
+    PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
+    vector<PageImageInfo> result = loader->extractImages();
+    
+    PyObject *converted = vectorPagesToList(result);
+    return Py_BuildValue("O", converted);
+}
+
+PyObject *deleteObject(PyObject *self, PyObject *args) {
+    PyObject *loaderCapsule;
+    PyArg_ParseTuple(args, "O", &loaderCapsule);
+    
+    PdfLoader *loader = (PdfLoader *)PyCapsule_GetPointer(loaderCapsule, "loaderPtr");
+	
     if (loader) {
         delete loader;
     }

--- a/src/xpydf/PdfLoaderWrapper.cc
+++ b/src/xpydf/PdfLoaderWrapper.cc
@@ -35,10 +35,9 @@ PyObject *construct(PyObject *self, PyObject *args) {
     
     PdfLoader *loader = new PdfLoader(config, fileName, ownerPw, userPw);
 
-    errCode = loader->getErrorCode();
-	
     if (!loader->isOk()) {
-        char message[1000] = "";
+        errCode = loader->getErrorCode();
+	char message[1000] = "";
         snprintf(message, 1000, "Error loading file %s", fileName);
         PyErr_SetString(PyExc_Exception, message);
 		switch (errCode) {		


### PR DESCRIPTION
I've added some code for improved error Exception handling.
for reference i've used the xpdf source from src\xpdf-4.04\xpdf\ErrorCodes.h

```
//========================================================================
//
// ErrorCodes.h
//
// Copyright 2002-2003 Glyph & Cog, LLC
//
//========================================================================

#ifndef ERRORCODES_H
#define ERRORCODES_H

#define errNone             0	// no error

#define errOpenFile         1	// couldn't open the PDF file

#define errBadCatalog       2	// couldn't read the page catalog

#define errDamaged          3	// PDF file was damaged and couldn't be
				// repaired

#define errEncrypted        4	// file was encrypted and password was
				// incorrect or not supplied

#define errHighlightFile    5	// nonexistent or invalid highlight file

#define errBadPrinter       6   // invalid printer

#define errPrinting         7   // error during printing

#define errPermission       8	// PDF file doesn't allow that operation

#define errBadPageNum       9	// invalid page number

#define errFileIO          10   // file I/O error

#endif

```