### PR TITLE
Building on Windows Failed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,10 +157,6 @@ cXpdfPython = Extension(
 
 class custom_build_ext(build_ext):
     def build_extensions(self):
-        # Force building all files as c++, cannot combine multiple compilers I think :'(
-        # It's deprecated behaviour, but eh
-        compiler = self.compiler.compiler_cxx[:1] + self.compiler.compiler_so[1:]
-        self.compiler.set_executable("compiler_so", " ".join(compiler))
         build_ext.build_extensions(self)
 
 setup(ext_modules=[cXpdfPython], cmdclass={"build_ext": custom_build_ext})

--- a/src/xpydf/PdfLoader.cc
+++ b/src/xpydf/PdfLoader.cc
@@ -159,7 +159,7 @@ std::vector<PageImageInfo> PdfLoader::extractPageInfo() {
       doc->displayPages(imageOut, page, page, 72, 72, 0, gFalse, gTrue, gFalse);
 
       std::vector<ImageInfo> images(imageOut->images);
-      pagesInfo.push_back((PageImageInfo){
+      pagesInfo.push_back(PageImageInfo{
         page,
         page_width,
         page_height,


### PR DESCRIPTION
setup.py
AttributeError: 'MSVCCompiler' object has no attribute 'compiler_cxx'

src\PdfLoader.cc
src\xpydf\PdfLoader.cc(167): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax

Tested on Both Windows (MVSC) and Ubuntu (GCC)